### PR TITLE
Add missing 'Bearer' to auth header

### DIFF
--- a/api/metrics_api.md
+++ b/api/metrics_api.md
@@ -25,7 +25,7 @@ You can extract metrics from an {{site.data.keyword.mon_full_notm}} instance by 
 You can use the following [cURL command](/docs/monitoring?topic=monitoring-mon-curl) to get metrics:
 
 ```text
-curl -X POST <SYSDIG_REST_API_ENDPOINT>/data -H "Authorization: $AUTH_TOKEN" -H "IBMInstanceID: $GUID" -H "SysdigTeamID: $TEAM_ID" -H "content-type: application/json" -d DATA
+curl -X POST <SYSDIG_REST_API_ENDPOINT>/data -H "Authorization: Bearer $AUTH_TOKEN" -H "IBMInstanceID: $GUID" -H "SysdigTeamID: $TEAM_ID" -H "content-type: application/json" -d DATA
 ```
 {: codeblock}
 
@@ -231,7 +231,7 @@ To get the latest value of a metric, specify only the metric name. The most rece
 For instance, to get the latest value of `host_cpu_used_percent`:
 
 ```text
-curl <SYSDIG_REST_API_ENDPOINT>/prometheus/api/v1/query?query=sysdig_host_cpu_used_percent -H "Authorization: $AUTH_TOKEN" -H "IBMInstanceID: $GUID" -H "SysdigTeamID: $TEAM_ID" -H "content-type: application/json"
+curl <SYSDIG_REST_API_ENDPOINT>/prometheus/api/v1/query?query=sysdig_host_cpu_used_percent -H "Authorization: Bearer $AUTH_TOKEN" -H "IBMInstanceID: $GUID" -H "SysdigTeamID: $TEAM_ID" -H "content-type: application/json"
 ```
 {: codeblock}
 


### PR DESCRIPTION
Thanks for taking the time to contribute to the IBM Cloud docs! After you open your pull request, a maintainer should review it soon.

We don't merge changes directly in this repository because content is not published from here. However, we'll incorporate any changes in our upstream repository so that they're reflected in the docs.

### Description

Most places in the doc correctly illustrate how to construct the required authorization header, but a couple are missing the required "Bearer" string.

###  Any other comments?

<!-- Add additional information or screenshots that you think we need.-->

---

### For reviewers (This section is only for IBMers)

You can't merge pull requests here.

- If you can incorporate these changes, copy them to your GitHub Enterprise repo. Leave a comment and close the pull request.
- If you can't accept the changes, leave information about why, and close the pull request.

If you don't have permission to close the request, ask for help in the IBM Cloud \#docs Slack channel.
